### PR TITLE
Only retrieve open grant requests from C1 task search

### DIFF
--- a/gadjit/plugins/iga/conductorone_cron/api.py
+++ b/gadjit/plugins/iga/conductorone_cron/api.py
@@ -103,6 +103,11 @@ class ConductorOneAPIClient:
             "taskStates": ["TASK_STATE_OPEN"],
             "createdAfter": created_after,
             "currentStep": "TASK_SEARCH_CURRENT_STEP_APPROVAL",  # Only tasks awaiting an approval
+            "taskTypes": [
+                {
+                    "grant": {}
+                }
+            ],
         }
 
         response = requests.post(url, headers=headers, json=payload)

--- a/gadjit/plugins/iga/conductorone_cron/api.py
+++ b/gadjit/plugins/iga/conductorone_cron/api.py
@@ -103,11 +103,7 @@ class ConductorOneAPIClient:
             "taskStates": ["TASK_STATE_OPEN"],
             "createdAfter": created_after,
             "currentStep": "TASK_SEARCH_CURRENT_STEP_APPROVAL",  # Only tasks awaiting an approval
-            "taskTypes": [
-                {
-                    "grant": {}
-                }
-            ],
+            "taskTypes": [{"grant": {}}],
         }
 
         response = requests.post(url, headers=headers, json=payload)

--- a/gadjit/utils.py
+++ b/gadjit/utils.py
@@ -1,6 +1,6 @@
-import importlib
 import os
 
+from importlib.util import spec_from_file_location, module_from_spec
 from . import models
 
 
@@ -103,8 +103,8 @@ def load_plugins(plugin_type, config):
             )
 
             # Dynamically import the plugin module
-            spec = importlib.util.spec_from_file_location(plugin_name, plugin_path)
-            module = importlib.util.module_from_spec(spec)
+            spec = spec_from_file_location(plugin_name, plugin_path)
+            module = module_from_spec(spec)
             spec.loader.exec_module(module)
 
             # Instantiate the plugin


### PR DESCRIPTION
The current code for C1 task search is also retrieving access reviews. We only want access requests (grants).