### PR TITLE
Don't ask the LLM for an opinion if the entitlement is empty

### DIFF
--- a/gadjit/plugins/scoring/requester_profile_attribute_proximity/plugin.py
+++ b/gadjit/plugins/scoring/requester_profile_attribute_proximity/plugin.py
@@ -121,6 +121,11 @@ class RequesterProfileAttributeProximityScoringPlugin(BaseGadjitScoringPlugin):
             ValueError: If the field type is not supported.
             JSONDecodeError: If there is an issue decoding the JSON response.
         """
+
+        # Return early if entitlement_users is empty.
+        if not entitlement_users:
+            return []
+
         if field_type == "title_and_department":
             field_type_verbose = "job title"
             system_example_field_input = "Senior Analyst, Eng - Online Grocery"
@@ -204,6 +209,7 @@ class RequesterProfileAttributeProximityScoringPlugin(BaseGadjitScoringPlugin):
         Raises:
             None
         """
+
         entitlement_users_flattened = []
         for email, profile in entitlement_users.items():
             # entitlement_users_flattened.append(f"{email}: {profile[field_type]}")
@@ -296,6 +302,7 @@ class RequesterProfileAttributeProximityScoringPlugin(BaseGadjitScoringPlugin):
         The function uses the LLM plugin to query and determine the relationship score between the job title and group access control based on provided information.
         The output must be in JSON format with the key 'relationship_score'.
         """
+
         user_prompt = (
             f"A new applicant wants to join the group. The applicant has the job title "
             f'of:\n"{task_target_profile_title_dept}"\n\nThe group\'s '


### PR DESCRIPTION
```
[ERROR]	2024-09-06T16:29:04.903Z	ce68c41e-5dfa-4ada-bd86-6ee93a6ec858	The following content caused the JSONDecodeError: I'm sorry, but it appears that you've started the list of the group's membership and job titles but did not include any names or titles. If you provide me with the necessary details, I'll be able to assist you further.
```

GPT-4 doesn't return the empty JSON requested and will instead say the data is malformed. Don't even bother querying the LLM if the entitlement is empty and therefore will not even have matches to sift through.