### PR TITLE
Handle no profile on user object within a task

### DIFF
--- a/gadjit/plugins/iga/conductorone_cron/api.py
+++ b/gadjit/plugins/iga/conductorone_cron/api.py
@@ -259,7 +259,7 @@ class ConductorOneAPIClient:
             for user in users:
                 okta_user = user.get("appUser").get("appUser")
                 email = okta_user.get("email")
-                profile = okta_user.get("profile")
+                profile = okta_user.get("profile") or {}
 
                 entitlement_users[email] = {
                     "id": okta_user.get("identityUserId"),


### PR DESCRIPTION
C1 does not include the 'profile' field on the user object for C1-native entitlements. Handle that gracefully.